### PR TITLE
Removing the hard coupling between Drest and the AnnotationDriver.

### DIFF
--- a/src/Drest/Configuration.php
+++ b/src/Drest/Configuration.php
@@ -19,7 +19,6 @@ use DrestCommon\Response\Response;
 
 class Configuration
 {
-
     const DETECT_CONTENT_HEADER = 1;
     const DETECT_CONTENT_EXTENSION = 2;
     const DETECT_CONTENT_PARAM = 3;
@@ -58,6 +57,8 @@ class Configuration
         // Use Json and XML as the default representations
         // @todo: This probably should be registered in this way. Use a similar method as the adapter classes
         $this->setDefaultRepresentations(array('Json', 'Xml'));
+        // Set the default method for retreiving class metadata.
+        $this->setMetadataDriverClass('\Drest\Mapping\Driver\AnnotationDriver');
         // register the default request adapter classes
         $this->_attributes['requestAdapterClasses'] = [];
         $this->registerRequestAdapterClasses(Request::$defaultAdapterClasses);
@@ -102,6 +103,24 @@ class Configuration
     {
         $this->_attributes['defaultRepresentations'] = $representations;
     }
+
+    /**
+     * Sets the class name of the metadata driver for instantiation.
+     *
+     * @param string $driver
+     */
+    public function setMetadataDriverClass($driver) {
+        $this->_attributes['metaDataDriver'] = $driver;
+    }
+
+    /**
+     * Returns the class name of the metadata driver.
+     * @return string The namespaced class name.
+     */
+    public function getMetadataDriverClass() {
+        return $this->_attributes['metaDataDriver'];
+    }
+
 
     /**
      * Register an array of request adapter classes

--- a/src/Drest/Manager.php
+++ b/src/Drest/Manager.php
@@ -118,8 +118,11 @@ class Manager
         Configuration $config,
         Event\Manager $eventManager = null)
     {
-        // Register the annotations classes
-        Mapping\Driver\AnnotationDriver::registerAnnotations();
+        $driver = $config->getMetadataDriverClass();
+
+        if(method_exists($driver, 'register')) {
+            $driver::register($config);
+        }
 
         return new self($entityManagerRegistry, $config, ($eventManager) ?: new Event\Manager());
     }
@@ -443,7 +446,7 @@ class Manager
     }
 
     /**
-     * Iterates through annotation definitions, any exceptions thrown will bubble up.
+     * Iterates through mapping definitions, any exceptions thrown will bubble up.
      */
     public function checkDefinitions()
     {

--- a/src/Drest/Manager/Metadata.php
+++ b/src/Drest/Manager/Metadata.php
@@ -12,9 +12,7 @@
  */
 namespace Drest\Manager;
 
-use Doctrine\Common\Annotations\AnnotationReader;
 use Drest\Mapping\MetadataFactory;
-use Drest\Mapping\Driver\AnnotationDriver;
 use Drest\Configuration;
 use Drest\Router;
 
@@ -28,8 +26,8 @@ class Metadata
     protected $metadataFactory;
 
     /**
-     * Annotation Driver being used
-     * @var AnnotationDriver $metaDataDriver
+     * Mapping Driver being used
+     * @var DriverInterface $metaDataDriver
      */
     protected $metaDataDriver;
 
@@ -39,8 +37,9 @@ class Metadata
      */
     public function __construct(Configuration $config)
     {
-        $this->metaDataDriver = AnnotationDriver::create(
-            new AnnotationReader(),
+        $driver = $config->getMetadataDriverClass();
+
+        $this->metaDataDriver = $driver::create(
             $config->getPathsToConfigFiles()
         );
 

--- a/src/Drest/Mapping/Driver/AnnotationDriver.php
+++ b/src/Drest/Mapping/Driver/AnnotationDriver.php
@@ -3,6 +3,7 @@
 namespace Drest\Mapping\Driver;
 
 use Doctrine\Common\Annotations;
+use Drest\Configuration;
 use Drest\DrestException;
 use Drest\Mapping\Annotation;
 use Drest\Mapping;
@@ -308,13 +309,18 @@ class AnnotationDriver implements DriverInterface
      * @param  array|string                 $paths
      * @return AnnotationDriver
      */
-    public static function create(Annotations\AnnotationReader $reader = null, $paths = [])
+    public static function create($paths = [])
     {
-        if ($reader == null) {
-            $reader = new Annotations\AnnotationReader();
-        }
+        $reader = new Annotations\AnnotationReader();
 
         return new self($reader, (array) $paths);
+    }
+
+    /**
+     * Driver registration template method.
+     */
+    public static function register(Configuration $config) {
+        self::registerAnnotations();
     }
 
     /**

--- a/tests/DrestTests/Mapping/ClassMetaDataTest.php
+++ b/tests/DrestTests/Mapping/ClassMetaDataTest.php
@@ -84,7 +84,6 @@ class ClassMetaDataTest extends DrestTestCase
     {
         $metadataFactory = new MetadataFactory(
             \Drest\Mapping\Driver\AnnotationDriver::create(
-                new AnnotationReader(),
                 array(__DIR__ . '/../Entities/NoServiceDefinition')
             )
         );
@@ -101,7 +100,6 @@ class ClassMetaDataTest extends DrestTestCase
     {
         $metadataFactory = new MetadataFactory(
             \Drest\Mapping\Driver\AnnotationDriver::create(
-                new AnnotationReader(),
                 array(__DIR__ . '/../Entities/MissingMetaData')
             )
         );
@@ -118,7 +116,6 @@ class ClassMetaDataTest extends DrestTestCase
     {
         $metadataFactory = new MetadataFactory(
             \Drest\Mapping\Driver\AnnotationDriver::create(
-                new AnnotationReader(),
                 array(__DIR__ . '/../Entities/DuplicatedRouteName')
             )
         );
@@ -134,7 +131,6 @@ class ClassMetaDataTest extends DrestTestCase
     {
         $metadataFactory = new MetadataFactory(
             \Drest\Mapping\Driver\AnnotationDriver::create(
-                new AnnotationReader(),
                 array(__DIR__ . '/../Entities/InvalidVerbUsed')
             )
         );
@@ -150,7 +146,6 @@ class ClassMetaDataTest extends DrestTestCase
     {
         $metadataFactory = new MetadataFactory(
             \Drest\Mapping\Driver\AnnotationDriver::create(
-                new AnnotationReader(),
                 array(__DIR__ . '/../Entities/EmptyRouteName')
             )
         );
@@ -164,7 +159,7 @@ class ClassMetaDataTest extends DrestTestCase
      */
     public function testMissingPathToConfigFiles()
     {
-        $driver = \Drest\Mapping\Driver\AnnotationDriver::create(new AnnotationReader());
+        $driver = \Drest\Mapping\Driver\AnnotationDriver::create();
         $driver->getAllClassNames();
     }
 
@@ -175,7 +170,6 @@ class ClassMetaDataTest extends DrestTestCase
     {
         $metadataFactory = new MetadataFactory(
             \Drest\Mapping\Driver\AnnotationDriver::create(
-                new AnnotationReader(),
                 array(__DIR__ . '/../Entities/HandleAlreadyDefined')
             )
         );
@@ -191,7 +185,6 @@ class ClassMetaDataTest extends DrestTestCase
     {
         $metadataFactory = new MetadataFactory(
             \Drest\Mapping\Driver\AnnotationDriver::create(
-                new AnnotationReader(),
                 array(__DIR__ . '/../Entities/HandleDoesntMatchRouteName')
             )
         );
@@ -206,7 +199,6 @@ class ClassMetaDataTest extends DrestTestCase
     {
         $metadataFactory = new MetadataFactory(
             \Drest\Mapping\Driver\AnnotationDriver::create(
-                new AnnotationReader(),
                 array(__DIR__ . '/../Entities/Typical')
             )
         );
@@ -220,7 +212,6 @@ class ClassMetaDataTest extends DrestTestCase
     {
         $metadataFactory = new MetadataFactory(
             \Drest\Mapping\Driver\AnnotationDriver::create(
-                new AnnotationReader(),
                 array(__DIR__ . '/../Entities/Typical')
             )
         );
@@ -234,7 +225,6 @@ class ClassMetaDataTest extends DrestTestCase
     {
         $metadataFactory = new MetadataFactory(
             \Drest\Mapping\Driver\AnnotationDriver::create(
-                new AnnotationReader(),
                 array(__DIR__ . '/../Entities/Typical')
             )
         );
@@ -248,7 +238,6 @@ class ClassMetaDataTest extends DrestTestCase
     {
         $metadataFactory = new MetadataFactory(
             \Drest\Mapping\Driver\AnnotationDriver::create(
-                new AnnotationReader(),
                 array(__DIR__ . '/../Entities/Typical')
             )
         );
@@ -262,7 +251,6 @@ class ClassMetaDataTest extends DrestTestCase
     {
         $metadataFactory = new MetadataFactory(
             \Drest\Mapping\Driver\AnnotationDriver::create(
-                new AnnotationReader(),
                 array(__DIR__ . '/../Entities/Typical')
             )
         );
@@ -287,7 +275,6 @@ class ClassMetaDataTest extends DrestTestCase
     {
         $metadataFactory = new MetadataFactory(
             \Drest\Mapping\Driver\AnnotationDriver::create(
-                new AnnotationReader(),
                 array(__DIR__ . '/../Entities/Typical')
             )
         );
@@ -302,7 +289,6 @@ class ClassMetaDataTest extends DrestTestCase
     public function testRemovingExtension()
     {
         $annotationDriver = \Drest\Mapping\Driver\AnnotationDriver::create(
-            new AnnotationReader(),
             array(__DIR__ . '/../Entities/Typical')
         );
 


### PR DESCRIPTION
This removes some of the tight coupling in this aspect of the metadata parsing. The goal here is to be able to use drivers other than annotations (specifically yaml) to power Drest. Drivers for Yaml, Json, and PHP will be coming in a later commit.